### PR TITLE
write plugin configuration into a subdirectory.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,18 @@ class fluentbit::config {
     }
   }
 
+  # the @INCLUDE command does not support absolute paths
+  # so we create the directory next to the main configuration file
+  # and reference it relatively. since the include instruction is
+  # hardcoded in the configuration file, we need to create the
+  # directory otherwise the daemon fails with '[mk_rconf_read_glob] glob: no match'
+  file { "${config_dir}/plugins.d":
+    ensure  => directory,
+    purge   => $fluentbit::manage_config_dir,
+    recurse => $fluentbit::manage_config_dir,
+    mode    => '0755',
+  }
+
   $flush = $fluentbit::flush
   $daemon = bool2str($fluentbit::daemon, 'On', 'Off')
   $log_file = $fluentbit::log_file

--- a/manifests/filter/modify.pp
+++ b/manifests/filter/modify.pp
@@ -27,7 +27,7 @@
 # @example
 #   fluentbit::filter::modify { 'namevar': }
 define fluentbit::filter::modify (
-  String $configfile         = '/etc/td-agent-bit/filter_modify.conf',
+  Stdlib::Absolutepath $configfile = "/etc/td-agent-bit/plugins.d/filter_modify_${name}.conf",
   String $match              = '*',
   Optional $set              = undef,
   Optional $add              = undef,

--- a/manifests/input/forward.pp
+++ b/manifests/input/forward.pp
@@ -19,7 +19,7 @@
 #  The value must be according to the Unit Size specification.
 #
 define fluentbit::input::forward (
-    String $configfile                    = "/etc/td-agent-bit/input_forward_${name}.conf",
+    Stdlib::Absolutepath $configfile      = "/etc/td-agent-bit/plugins.d/input_forward_${name}.conf",
     Stdlib::IP::Address::Nosubnet $listen = '0.0.0.0',
     Stdlib::Port $port                    = 24224,
     Optional[String] $buffer_max_size     = undef,

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -36,7 +36,7 @@ define fluentbit::input::syslog(
     default  => undef,
   },
   String $parser = 'syslog-rfc3164',
-  String $configfile = '/etc/td-agent-bit/input_syslog.conf',
+  Stdlib::Absolutepath $configfile = "/etc/td-agent-bit/plugins.d/input_syslog_${name}.conf",
   String $rsyslog_config = '/etc/rsyslog.d/60-fluent-bit.conf',
 ) {
   # create input_syslog.conf

--- a/manifests/input/tail.pp
+++ b/manifests/input/tail.pp
@@ -83,7 +83,7 @@
 #
 define fluentbit::input::tail (
   Stdlib::Absolutepath $path,
-  Stdlib::Absolutepath $configfile                          = "/etc/td-agent-bit/input_tail_${name}.conf",
+  Stdlib::Absolutepath $configfile                          = "/etc/td-agent-bit/plugins.d/input_tail_${name}.conf",
   Optional[String[1]] $routing_tag                          = undef,
   Optional[Enum['memory', 'filesystem']] $storage_type      = undef,
 

--- a/manifests/output/es.pp
+++ b/manifests/output/es.pp
@@ -66,7 +66,7 @@
 # @example
 #  include fluentbit::output::es
 define fluentbit::output::es (
-  String $configfile            = "/etc/td-agent-bit/output_es_${name}.conf",
+  Stdlib::Absolutepath $configfile = "/etc/td-agent-bit/plugins.d/output_es_${name}.conf",
   String $match                 = '*',
   Stdlib::Host $host            = '127.0.0.1',
   Stdlib::Port $port            = 9200,

--- a/manifests/output/http.pp
+++ b/manifests/output/http.pp
@@ -70,7 +70,7 @@
 # @example
 #   fluentbit::output::http { 'logstash': }
 define fluentbit::output::http (
-  Stdlib::Absolutepath $configfile            = "/etc/td-agent-bit/output_http_${name}.conf",
+  Stdlib::Absolutepath $configfile            = "/etc/td-agent-bit/plugins.d/output_http_${name}.conf",
   Fluentbit::TLS $tls                         = {},
   Hash[String[1], String[1]] $headers         = {},
   Variant[Undef, Boolean, Integer[1]]

--- a/spec/defines/input/tail_spec.rb
+++ b/spec/defines/input/tail_spec.rb
@@ -36,7 +36,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/input_tail_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/input_tail_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -63,7 +63,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/input_tail_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/input_tail_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -88,7 +88,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/input_tail_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/input_tail_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -116,7 +116,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/input_tail_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/input_tail_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -150,7 +150,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/input_tail_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/input_tail_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -181,7 +181,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/input_tail_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/input_tail_rspec.conf')
             .with_content(rendered)
         end
       end

--- a/spec/defines/output/http_spec.rb
+++ b/spec/defines/output/http_spec.rb
@@ -30,7 +30,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -63,7 +63,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -84,7 +84,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -105,7 +105,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -126,7 +126,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -157,7 +157,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end
@@ -190,7 +190,7 @@ EOF
         end
 
         it do
-          is_expected.to contain_file('/etc/td-agent-bit/output_http_rspec.conf')
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/output_http_rspec.conf')
             .with_content(rendered)
         end
       end

--- a/templates/td-agent-bit.conf.erb
+++ b/templates/td-agent-bit.conf.erb
@@ -28,6 +28,4 @@
     storage.backlog.mem_limit <%= @storage_backlog_mem_limit %>
 <% end -%>
 
-@INCLUDE input_*.conf
-@INCLUDE output_*.conf
-@INCLUDE filter_*.conf
+@INCLUDE plugins.d/*.conf


### PR DESCRIPTION
the @INCLUDE directive fails if a wildcard does not resolve. since
it is a possible to have a fluentbit pipeline without any filters,
the service would fail to start.
this change assembles the configuration files under a single
directory and uses a single glob directive to load them. fluenbit
reads the files in an alphanumeric order but internally sorts
them correctly (input-filter-output)

BREAKING: the values of the *configfile* parameter of the defined types for plugins have changed.
if you provided those values manually in the past, changes are the config is no longer picked up
by the fluentbit daemon.

fixes #21 