### PR TITLE
Don't contain the fluentbit::service, include it

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,7 +188,7 @@ class fluentbit (
   contain fluentbit::repo
   contain fluentbit::install
   contain fluentbit::config
-  contain fluentbit::service
+  include fluentbit::service
 
   Class['::fluentbit::repo']
     -> Class['::fluentbit::install']


### PR DESCRIPTION
Contain'ing it means that someone cannot do something simple like:

```
include ::fluentbit, ::fluentbit::service
file { ....:
  require => Class[::fluentbit],
  notify   => Class[::fluentbit::service]
}
```