### PR TITLE
Several small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,15 @@ Wait period time in seconds to flush queued unfinished split lines.
 
 Default value: `undef`
 
+##### `read_from_head`
+
+Data type: `Boolean`
+
+For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail.
+
+Default value: `false`
+
+
 ### fluentbit::output::es
 
 Plugin to output logs to a configured elasticsearch instance

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -103,17 +103,16 @@ fluentbit::parsers:
 
   - name:        'syslog-rfc3164-local'
     format:      'regex'
-    regex:       '^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
+    regex:       '^(?:\<(?<pri>[0-9]+)\>)?(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
     time_key:    'time'
     time_format: '%b %d %H:%M:%S'
     time_keep:   true
 
   - name:        'syslog-rfc3164'
     format:      'regex'
-    regex:       '/^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/'
+    regex:       '^(?:\<(?<pri>[0-9]+)\>)?(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
     time_key:    'time'
     time_format: '%b %d %H:%M:%S'
-    time_format: '%Y-%m-%dT%H:%M:%S.%L'
     time_keep:   true
 
   - name:    'mongodb'

--- a/manifests/filter/lua.pp
+++ b/manifests/filter/lua.pp
@@ -1,0 +1,16 @@
+define fluentbit::filter::lua (
+  String $configfile         = "/etc/td-agent-bit/filter_lua_${name}.conf",
+  String $match              = '*',
+  String $script             = undef,
+  String $call               = undef,
+) {
+  # create filter_modify.conf
+  # TODO: concat for multiple entries
+  file { $configfile:
+    ensure  => file,
+    mode    => '0644',
+    content => template('fluentbit/filter/lua.conf.erb'),
+    notify  => Class['fluentbit::service'],
+    require => Class['fluentbit::install'],
+  }
+}

--- a/manifests/input/tail.pp
+++ b/manifests/input/tail.pp
@@ -95,6 +95,7 @@ define fluentbit::input::tail (
   Optional[Integer[1]] $rotate_wait                         = undef,
   Optional[Fluentbit::Timeunit] $ignore_older               = undef,
   Boolean $skip_long_lines                                  = false,
+  Boolean $read_from_head                                   = false,
   Optional[Stdlib::Absolutepath] $db                        = undef,
   Optional[Enum['Extra', 'Full', 'Normal', 'Off']] $db_sync = undef,
   Optional[Fluentbit::Sizeunit] $mem_buf_limit              = undef,
@@ -110,6 +111,7 @@ define fluentbit::input::tail (
 ) {
   $skip_long_lines_string = bool2str($skip_long_lines, 'On', 'Off')
   $docker_mode_string = bool2str($docker_mode, 'On', 'Off')
+  $read_from_head_string = bool2str($read_from_head, 'On', 'Off')
 
   file { $configfile:
     ensure  => file,

--- a/manifests/output/es.pp
+++ b/manifests/output/es.pp
@@ -63,18 +63,38 @@
 #  Use current time for index generation instead of message record
 # @param logstash_prefix_key
 #  Prefix keys with this string
+# @param aws_auth
+# Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service (On/Off)
+# @param aws_region
+# Specify the AWS region for Amazon ElasticSearch Service
+# @param aws_sts_endpoint
+# Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service
+# @param aws_role_arn
+# AWS IAM Role to assume to put records to your Amazon ES cluster
+# @param aws_external_id
+# External ID for the AWS IAM Role specified with aws_role_arn
+
 # @example
 #  include fluentbit::output::es
 define fluentbit::output::es (
-  String $configfile            = "/etc/td-agent-bit/output_es_${name}.conf",
-  String $match                 = '*',
-  Stdlib::Host $host            = '127.0.0.1',
-  Stdlib::Port $port            = 9200,
-  String $index                 = 'fluentbit',
-  String $type                  = 'flb_type',
-  Enum['on', 'off'] $tls        = 'off',
-  Optional[String] $http_user   = undef,
-  Optional[String] $http_passwd = undef,
+  String $configfile                            = "/etc/td-agent-bit/output_es_${name}.conf",
+  String $match                                 = '*',
+  Stdlib::Host $host                            = '127.0.0.1',
+  Stdlib::Port $port                            = 9200,
+  String $index                                 = 'fluentbit',
+  Optional[String] $type                        = undef,
+  Enum['On', 'Off', 'on', 'off'] $tls           = 'Off',
+  Optional[String] $http_user                   = undef,
+  Optional[String] $http_passwd                 = undef,
+  Optional[Enum['On', 'Off']] $logstash_format  = undef,
+  String $logstash_prefix                       = $index,
+  String $logstash_dateformat                   = '%Y.%m.%d',
+  Optional[Enum['On', 'Off']] $replace_dots     = undef,
+  Optional[Enum['On', 'Off']] $aws_auth         = undef,
+  Optional[String] $aws_region                  = undef,
+  Optional[String] $aws_sts_endpoint            = undef,
+  Optional[String] $aws_role_arn                = undef,
+  Optional[String] $aws_external_id             = undef, 
 ) {
   file { $configfile:
     ensure  => file,

--- a/templates/filter/lua.conf.erb
+++ b/templates/filter/lua.conf.erb
@@ -1,0 +1,8 @@
+# Managed by puppet
+# Filter to modify output
+[FILTER]
+    # configure plugins
+    Name          lua
+    Match         <%= @match %>
+    script        <%= @script %>
+    call          <%= @call %>

--- a/templates/input/tail.conf.erb
+++ b/templates/input/tail.conf.erb
@@ -31,6 +31,9 @@
 <% if @skip_long_lines_string -%>
     Skip_Long_Lines   <%= @skip_long_lines_string %>
 <% end -%>
+<% if @read_from_head_string -%>
+    Read_from_Head   <%= @read_from_head_string %>
+<% end -%>
 <% if @db -%>
     DB                <%= @db %>
 <% end -%>

--- a/templates/output/es.conf.erb
+++ b/templates/output/es.conf.erb
@@ -25,3 +25,26 @@
 <% if @http_passwd -%>
     HTTP_Passwd <%= @http_passwd %>
 <% end -%>
+<% if @logstash_format -%>
+    Logstash_Format <%= @logstash_format %>
+    Logstash_Prefix <%= @logstash_prefix %>
+    Logstash_DateFormat <%= @logstash_dateformat %>
+<% end -%>
+<% if @aws_auth -%>
+    AWS_Auth <%= @aws_auth %>
+<% if @aws_region -%>
+    AWS_Region <%= @aws_region %>
+<% end -%>
+<% if @aws_sts_endpoint -%>
+    AWS_STS_Endpoint <%= @aws_sts_endpoint %>
+<% end -%>
+<% if @aws_role_arn -%>
+    AWS_Role_ARN <%= @aws_role_arn %>
+<% end -%>
+<% if @aws_external_id -%>
+    AWS_External_ID <%= @aws_external_id %>
+<% end -%>
+<% end -%>
+<% if @replace_dots -%>
+    Replace_Dots <%=@replace_dots%>
+<% end -%>


### PR DESCRIPTION
Hi,

We created a few updates for your module that should make it more generally usable
- we added support for read_from_head to input::tail
- we made the priority field in syslog parsers optional so it can be used for syslog generated logfiles on centos/rhel-like systems
- we removed a duplicate time_format key in the syslog-rfc3164 parser
- we added several options for the output::es (including support for aws-authentication)
- we added support for lua filters